### PR TITLE
Added conversion from js.html.ImageData to Pixels abstract

### DIFF
--- a/src/hxDaedalus/data/math/Potrace.hx
+++ b/src/hxDaedalus/data/math/Potrace.hx
@@ -7,14 +7,7 @@ import hxDaedalus.data.graph.GraphEdge;
 import hxDaedalus.data.graph.GraphNode;
 import hxDaedalus.data.math.Point2D;
 import hxDaedalus.graphics.SimpleDrawingContext;
-#if ( !openfl && !nme && !html5 && js )
-	import hxDaedalus.graphics.js.CanvasPixelMatrix;
-#else
-	import hxDaedalus.graphics.Pixels;
-#end
-#if ( !openfl && !nme && !html5 && js )
-	typedef Pixels = hxDaedalus.graphics.js.CanvasPixelMatrix;
-#end
+import hxDaedalus.graphics.Pixels;
 	
 class Potrace
 {

--- a/src/hxDaedalus/factories/BitmapObject.hx
+++ b/src/hxDaedalus/factories/BitmapObject.hx
@@ -7,14 +7,7 @@ import hxDaedalus.data.graph.Graph;
 import hxDaedalus.data.math.Potrace;
 import hxDaedalus.debug.Debug;
 import hxDaedalus.graphics.SimpleDrawingContext;
-#if ( !openfl && !nme && !html5 && js ) 
-	import hxDaedalus.graphics.js.CanvasPixelMatrix;
-#else
-	import hxDaedalus.graphics.Pixels;
-#end
-#if ( !openfl && !nme && !html5 && js )
-	typedef Pixels = hxDaedalus.graphics.js.CanvasPixelMatrix;
-#end
+import hxDaedalus.graphics.Pixels;
 
 class BitmapObject
 {

--- a/src/hxDaedalus/graphics/Pixels.hx
+++ b/src/hxDaedalus/graphics/Pixels.hx
@@ -197,7 +197,21 @@ abstract Pixels(PixelsData)
 		
 		image.getRaster().setPixels(0, 0, this.width, this.height, buffer);
 	}
-	
+
+#elseif js	// plain js - conversion from ImageData
+
+	@:from static public function fromImageData(image:js.html.ImageData) {
+		var pixels = new Pixels(image.width, image.height, true);
+		
+		var data = image.data;
+		
+		for (i in 0...data.byteLength) {
+			pixels.bytes.set(i, data[i]);
+		}
+		
+		return pixels;
+	}
+
 #end
 }
 


### PR DESCRIPTION
See https://github.com/Justinfront/hxDaedalus/issues/26#issuecomment-68596669

As you can see it fits nicely into the Pixels class with just a few lines. 
It should replace CanvasMatrix (but feel free to not merge it) and be used like:
```
var pixels = context.getImageData(0, 0, w, h);
```

About the cross-origin issues we're facing... the demos seem to work fine if you fire up a webserver, not sure why they don't work on rawgit (as they're running without problems on dropbox f.e.).